### PR TITLE
Use QtBluetooth enums from their namespace

### DIFF
--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -41,16 +41,16 @@
 #define WAHOO_BRAKE_CONTROL_UUID "{A026E005-0A7D-4AB3-97FA-F1500F9FEB8B}"
 
 QMap<QBluetoothUuid, btle_sensor_type_t> BT40Device::supportedServices = {
-    { QBluetoothUuid(QBluetoothUuid::HeartRate),                { "Heartrate", ":images/IconHR.png" }},
-    { QBluetoothUuid(QBluetoothUuid::CyclingPower),             { "Power", ":images/IconPower.png" }},
-    { QBluetoothUuid(QBluetoothUuid::CyclingSpeedAndCadence),   { "Speed + Cadence", ":images/IconCadence.png" }},
+    { QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::HeartRate),                { "Heartrate", ":images/IconHR.png" }},
+    { QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::CyclingPower),             { "Power", ":images/IconPower.png" }},
+    { QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::CyclingSpeedAndCadence),   { "Speed + Cadence", ":images/IconCadence.png" }},
     { QBluetoothUuid(QString(VO2MASTERPRO_SERVICE_UUID)),       { "VM Pro", ":images/IconCadence.png" }},
     { QBluetoothUuid(QString(BLE_TACX_UART_UUID)),              { "Tacx FE-C over BLE", ":images/IconPower.png" }},
     { s_KurtInRideService_UUID,                                 { "Kurt Kinetic Inride over BLE", ":images/IconPower.png" }},
     { s_KurtSmartControlService_UUID,                           { "Kurt Kinetic Smart Control over BLE", ":images/IconPower.png" }},
 
     // This will be needed if we decide to query DeviceInfo for SystemID
-    //{ QBluetoothUuid(QBluetoothUuid::DeviceInformation),        { "DeviceInformation", ":images / IconPower.png"}},
+    //{ QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::DeviceInformation),        { "DeviceInformation", ":images / IconPower.png"}},
 };
 
 BT40Device::BT40Device(QObject *parent, QBluetoothDeviceInfo devinfo) : parent(parent), m_currentDevice(devinfo)
@@ -127,12 +127,12 @@ BT40Device::deviceDisconnected()
     // Zero any readings provided by this device
     foreach (QLowEnergyService* const &service, m_services) {
 
-        if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::HeartRate)) {
+        if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::HeartRate)) {
             dynamic_cast<BT40Controller*>(parent)->setBPM(0.0);
-        } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingPower)) {
+        } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::CyclingPower)) {
             dynamic_cast<BT40Controller*>(parent)->setWatts(0.0);
             dynamic_cast<BT40Controller*>(parent)->setWheelRpm(0.0);
-        } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingSpeedAndCadence)) {
+        } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::CyclingSpeedAndCadence)) {
             dynamic_cast<BT40Controller*>(parent)->setWheelRpm(0.0);
         } else if (service->serviceUuid() == QBluetoothUuid(QString(VO2MASTERPRO_SERVICE_UUID))) {
             BT40Controller *controller = dynamic_cast<BT40Controller*>(parent);
@@ -193,12 +193,12 @@ BT40Device::serviceScanDone()
         connect(service, SIGNAL(characteristicWritten(QLowEnergyCharacteristic,QByteArray)), this, SLOT(confirmedCharacteristicWrite(QLowEnergyCharacteristic,QByteArray)));
         connect(service, SIGNAL(error(QLowEnergyService::ServiceError)), this, SLOT(serviceError(QLowEnergyService::ServiceError)));
 
-        if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingPower)) {
+        if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::CyclingPower)) {
 
             has_power = true;
             service->discoverDetails();
 
-        } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingSpeedAndCadence)) {
+        } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::CyclingSpeedAndCadence)) {
 
             has_csc = true;
             csc_service = service;
@@ -236,28 +236,28 @@ BT40Device::serviceStateChanged(QLowEnergyService::ServiceState s)
             if (service->state() == s) {
 
                 QList<QLowEnergyCharacteristic> characteristics;
-                if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::HeartRate)) {
+                if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::HeartRate)) {
 
                     emit setNotification(tr("Connected to device / service: ") + m_currentDevice.name() + 
                                 " / HeartRate", 4);
                     characteristics.append(service->characteristic(
-                    QBluetoothUuid(QBluetoothUuid::HeartRateMeasurement)));
+                    QBluetoothUuid(QBluetoothUuid::CharacteristicType::HeartRateMeasurement)));
 
-                } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingPower)) {
+                } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::CyclingPower)) {
 
                     emit setNotification(tr("Connected to device / service: ") + m_currentDevice.name() + 
                                 " / CyclingPower", 4);
                     characteristics.append(service->characteristic(
-                    QBluetoothUuid(QBluetoothUuid::CyclingPowerMeasurement)));
+                    QBluetoothUuid(QBluetoothUuid::CharacteristicType::CyclingPowerMeasurement)));
                     characteristics.append(service->characteristic(
                                 QBluetoothUuid(QString(WAHOO_BRAKE_CONTROL_UUID))));
 
-                } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingSpeedAndCadence)) {
+                } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::CyclingSpeedAndCadence)) {
 
                     emit setNotification(tr("Connected to device / service: ") + m_currentDevice.name() + 
                                 " / CyclingSpeedAndCadence", 4);
                     characteristics.append(service->characteristic(
-                    QBluetoothUuid(QBluetoothUuid::CSCMeasurement)));
+                    QBluetoothUuid(QBluetoothUuid::CharacteristicType::CSCMeasurement)));
                 } else if (service->serviceUuid() == QBluetoothUuid(QString(VO2MASTERPRO_SERVICE_UUID))) {
 
                     emit setNotification(tr("Connected to device / service: ") + m_currentDevice.name() + 
@@ -312,7 +312,7 @@ BT40Device::serviceStateChanged(QLowEnergyService::ServiceState s)
 
                         } else if(characteristic.uuid() == QBluetoothUuid(QString(WAHOO_BRAKE_CONTROL_UUID))) {
                             qDebug() << "Starting indication for char with UUID: " << characteristic.uuid().toString();
-                            const QLowEnergyDescriptor notificationDesc = characteristic.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration);
+                            const QLowEnergyDescriptor notificationDesc = characteristic.descriptor(QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration);
                             if (notificationDesc.isValid()) {
                                 service->writeDescriptor(notificationDesc, QByteArray::fromHex("0200"));
                                 loadService = service;
@@ -381,7 +381,7 @@ BT40Device::serviceStateChanged(QLowEnergyService::ServiceState s)
 
                         } else {
                             qDebug() << "Starting notification for char with UUID: " << characteristic.uuid().toString();
-                            const QLowEnergyDescriptor notificationDesc = characteristic.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration);
+                            const QLowEnergyDescriptor notificationDesc = characteristic.descriptor(QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration);
                             if (notificationDesc.isValid()) {
                                 service->writeDescriptor(notificationDesc, QByteArray::fromHex("0100"));
                             }
@@ -399,7 +399,7 @@ BT40Device::updateValue(const QLowEnergyCharacteristic &c, const QByteArray &val
     QDataStream ds(value);
     ds.setByteOrder(QDataStream::LittleEndian); // Bluetooth data is always LE
 
-    if (c.uuid() == QBluetoothUuid(QBluetoothUuid::HeartRateMeasurement)) {
+    if (c.uuid() == QBluetoothUuid(QBluetoothUuid::CharacteristicType::HeartRateMeasurement)) {
         quint8 flags;
         ds >> flags;
         float hr;
@@ -414,7 +414,7 @@ BT40Device::updateValue(const QLowEnergyCharacteristic &c, const QByteArray &val
         }
         dynamic_cast<BT40Controller*>(parent)->setBPM(hr);
 
-    } else if (c.uuid() == QBluetoothUuid(QBluetoothUuid::CyclingPowerMeasurement)) {
+    } else if (c.uuid() == QBluetoothUuid(QBluetoothUuid::CharacteristicType::CyclingPowerMeasurement)) {
 
         quint16 flags;
         ds >> flags;
@@ -443,7 +443,7 @@ BT40Device::updateValue(const QLowEnergyCharacteristic &c, const QByteArray &val
             getCadence(ds);
         }
 
-    } else if (c.uuid() == QBluetoothUuid(QBluetoothUuid::CSCMeasurement)) {
+    } else if (c.uuid() == QBluetoothUuid(QBluetoothUuid::CharacteristicType::CSCMeasurement)) {
 
         quint8 flags;
         ds >> flags;


### PR DESCRIPTION
For increased type safety, some enums have been changed to
scoped enums in Qt 6.2, see
https://codereview.qt-project.org/c/qt/qtconnectivity/+/337069
https://codereview.qt-project.org/c/qt/qtconnectivity/+/336678
This patch adapts subsurface to this change.
Since C++11, enums inject their symbols in both their own
and their parent namespace, so this patch can be merged right
now.